### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "bash"
+run = "$ python main.py"

--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ $ python main.py
 ![demo1](https://raw.githubusercontent.com/marblexu/PythonPlantsVsZombies/master/demo/demo1.jpg)
 ![demo2](https://raw.githubusercontent.com/marblexu/PythonPlantsVsZombies/master/demo/demo2.jpg)
 
+[![Run on Repl.it](https://repl.it/badge/github/marblexu/PythonPlantsVsZombies)](https://repl.it/github/marblexu/PythonPlantsVsZombies)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@KamranB519/PythonPlantsVsZombies-1).